### PR TITLE
Markdown preview

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,3 +15,17 @@
 //= require turbolinks
 //= require bootstrap
 //= require_tree .
+function markdownPreview() {
+  var text = document.getElementById('wiki_body').value,
+      target = document.getElementById('wiki_preview'),
+      converter = new showdown.Converter(),
+      html = converter.makeHtml(text);
+
+    target.innerHTML = html;
+}
+
+$(document).ready(function() {
+  $('pre code').each(function(i, block) {
+    hljs.highlightBlock(block);
+  });
+});

--- a/app/assets/stylesheets/wikis.scss
+++ b/app/assets/stylesheets/wikis.scss
@@ -1,3 +1,8 @@
 // Place all the styles related to the wikis controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+#wiki_preview {
+  height: 100%;
+  border: 1px solid #c0c0c0;
+  background-color: #f0f0f0;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/showdown/1.3.0/showdown.min.js' %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js' %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <title>Blocipedia</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag '//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/default.min.css' %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/showdown/1.3.0/showdown.min.js' %>
   <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/highlight.min.js' %>

--- a/app/views/wikis/_wiki_form.html.erb
+++ b/app/views/wikis/_wiki_form.html.erb
@@ -15,7 +15,7 @@
   <% end %>
   <%= form_group_tag(wiki.errors[:body]) do %>
     <%= f.label :body %>
-    <%= f.text_area :body, class: 'form-control', placeholder: "Enter wiki here", rows: "8" %>
+    <%= f.text_area :body, class: 'form-control', onkeyup: 'markdownPreview()', placeholder: "Enter wiki here", rows: "8" %>
   <% end %>
   <% if current_user.premium? %>
     <div class="form-group">

--- a/app/views/wikis/_wiki_form.html.erb
+++ b/app/views/wikis/_wiki_form.html.erb
@@ -11,11 +11,11 @@
   <% end %>
   <%= form_group_tag(wiki.errors[:title]) do %>
     <%= f.label :title %>
-    <%= f.text_field :title, class: 'form-control', placeholder: "Enter wiki title here", autofocus: true %>
+    <%= f.text_field :title, class: 'form-control', placeholder: "Enter wiki title here", autofocus: true, onfocus: 'markdownPreview()' %>
   <% end %>
   <%= form_group_tag(wiki.errors[:body]) do %>
     <%= f.label :body %>
-    <%= f.text_area :body, class: 'form-control', onkeyup: 'markdownPreview()', placeholder: "Enter wiki here", rows: "8" %>
+    <%= f.text_area :body, class: 'form-control', onkeyup: 'markdownPreview();', placeholder: "Enter wiki here", rows: "8" %>
   <% end %>
   <% if current_user.premium? %>
     <div class="form-group">

--- a/app/views/wikis/edit.html.erb
+++ b/app/views/wikis/edit.html.erb
@@ -1,6 +1,6 @@
 <h1>Edit Wiki</h1>
 <div class"row">
-  <div class="col-md-8">
+  <div class="col-md-6">
     <ul>
       <p>Remember:</p>
       <li>Title must have at least 3 and at most 100 characters</li>
@@ -10,6 +10,8 @@
     </ul>
     <%= render partial: 'wiki_form', locals: { wiki: @wiki } %>
   </div>
+  <h3>Preview</h3>
+  <div id="wiki_preview" class="col-md-6"></div>
 </div>
 <% if @wiki.user == current_user %>
   <div class="row">

--- a/app/views/wikis/new.html.erb
+++ b/app/views/wikis/new.html.erb
@@ -3,5 +3,6 @@
   <div class="col-md-6">
     <%= render partial: 'wiki_form', locals: { wiki: @wiki } %>
   </div>
+  <h3>Preview</h3>
   <div id="wiki_preview" class="col-md-6"></div>
 </div>

--- a/app/views/wikis/new.html.erb
+++ b/app/views/wikis/new.html.erb
@@ -1,6 +1,7 @@
 <h1>New Wiki</h1>
 <div class"row">
-  <div class="col-md-8">
+  <div class="col-md-6">
     <%= render partial: 'wiki_form', locals: { wiki: @wiki } %>
   </div>
+  <div id="wiki_preview" class="col-md-6"></div>
 </div>


### PR DESCRIPTION
I added `shodownjs` and `highlightjs`.

But the highlight styling shows up only when I refresh the page.

I linked `#wiki_preview` to an `onfocus` event so that it is filled as soon as `wiki#edit` page opens.
